### PR TITLE
fix: /community の画像がデバイス幅で比率崩れする問題を修正 (#20)

### DIFF
--- a/src/components/Community/Voice/Voice.module.css
+++ b/src/components/Community/Voice/Voice.module.css
@@ -32,6 +32,7 @@
   margin: auto;
   opacity: 0.2;
   width: 90%;
+  height: auto;
 }
 .Voice__Lanes {
   padding-top: 20px;

--- a/src/components/Community/blocks/BlockInner/Discord/Discord.module.css
+++ b/src/components/Community/blocks/BlockInner/Discord/Discord.module.css
@@ -5,6 +5,7 @@
 }
 .Discord__Item {
   width: 100%;
+  height: auto;
 }
 @media screen and (min-width: 1280px) {
   .Discord__Images {

--- a/src/components/Community/blocks/BlockInner/Event/Event.module.css
+++ b/src/components/Community/blocks/BlockInner/Event/Event.module.css
@@ -3,6 +3,7 @@
 }
 .Event__HeroImg {
   width: 100%;
+  height: auto;
 }
 .Event__Detail {
   display: flex;
@@ -13,6 +14,7 @@
 }
 .Event__DetailImg {
   width: 100%;
+  height: auto;
 }
 .Event__DetailText {
   font-size: 11px;
@@ -22,6 +24,7 @@
 }
 .Event__RightImg {
   max-width: 100%;
+  height: auto;
 }
 .Event__Publication {
   border-top: 1px solid #000;

--- a/src/components/Community/blocks/BlockInner/OfflineMeeting/OfflineMeeting.module.css
+++ b/src/components/Community/blocks/BlockInner/OfflineMeeting/OfflineMeeting.module.css
@@ -1,8 +1,10 @@
 .OfflineMeeting {
   display: flex;
+  align-items: flex-start;
   gap: 18px;
   img {
     width: calc((100% - 18px)/2);
+    height: auto;
   }
 }
 @media screen and (min-width: 1280px) {

--- a/src/components/Community/blocks/BlockInner/Zoom/Zoom.module.css
+++ b/src/components/Community/blocks/BlockInner/Zoom/Zoom.module.css
@@ -1,6 +1,12 @@
 .Zoom__TopImage {
   max-width: 100%;
+  height: auto;
   margin-bottom: 20px;
+}
+.Zoom__Icon,
+.icons {
+  width: auto;
+  height: 40px;
 }
 .Zoom__IconWrapper {
   margin: 0 auto;


### PR DESCRIPTION
Closes #20

## 概要
`/community` の画像が画面幅によってアスペクト比が崩れる問題を修正しました。

## 原因
`next/image` の `<Image>` は `width`/`height` 属性を持つため、CSS で `width`（`100%` / `calc()` / `max-width:100%`）だけを可変化すると、`height` が元のピクセル値に固定されたまま残り、画面幅に応じて縦横比が歪んでいました。

## 修正内容
- 可変幅の画像に `height: auto` を付与（Discord / OfflineMeeting / Zoom トップ画像 / Event / Voice ロゴ）
- `OfflineMeeting` は flex 直下の 2 枚が `align-items: stretch`(既定) で高さを揃えられ引き伸ばされていたため `align-items: flex-start` に変更
- Zoom の特典アイコン（非正方形 SVG を JSX で `40x40` 固定）に `width: auto; height: 40px` を付与し本来比率を維持

## 確認方法
Playwright で `/community` の全画像について「レンダリング比 ÷ 元画像比」を計測。

| 幅 | 修正前の最大歪み | 修正後の最大歪み |
|----|----------------|----------------|
| SP (375px) | 約 11% | 0%（全21枚） |
| PC (1440px) | 約 33%（Zoom アイコン） | 1%未満（next/image の丸め誤差のみ） |

`npm run lint` / `npm run typecheck` パス済み。