### PR TITLE
feat: Career Path ページに SiiD YouTube への導線ボタンを追加

### DIFF
--- a/src/components/CareerPath/CareerPathList/CareerPathList.module.css
+++ b/src/components/CareerPath/CareerPathList/CareerPathList.module.css
@@ -20,6 +20,15 @@
   height: 400px;
 }
 
+.CareerPath__YouTubeLink {
+    width: 100%;
+    max-width: 440px;
+    margin: 0 auto 16px;
+    border: 1px solid var(--text);
+    border-radius: 60px;
+    background-color: var(--text);
+}
+
 .CareerPath__SurveyLink {
     width: 100%;
     max-width: 440px;
@@ -27,6 +36,13 @@
     border: 1px solid var(--text);
     border-radius: 60px;
     background-color: var(--text);
+}
+
+.CareerPath__YouTubeIcon {
+  flex-shrink: 0;
+  width: 29px;
+  height: 20px;
+  margin-left: 4px;
 }
 
 .CareerCard__SurveyLinkAnchor {
@@ -60,6 +76,15 @@
   .CareerPath__SurveyIcon {
     width: 32px;
     height: 32px;
+  }
+
+  .CareerPath__YouTubeIcon {
+    width: 35px;
+    height: 24px;
+  }
+
+  .CareerPath__YouTubeLink {
+    margin-bottom: 20px;
   }
 
   .CareerPathList__Grid {

--- a/src/components/CareerPath/CareerPathList/CareerPathList.tsx
+++ b/src/components/CareerPath/CareerPathList/CareerPathList.tsx
@@ -73,6 +73,28 @@ export default function CareerPathList({
           hasPrevPage={paginationInfo.hasPrevPage}
         />
 
+        <div className={styles.CareerPath__YouTubeLink}>
+          <Link
+            href="https://www.youtube.com/@programming-siid"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.CareerCard__SurveyLinkAnchor}
+          >
+            <span className={styles.CareerCard__SurveyText}>
+              その他の受講生様実績はこちら
+            </span>
+
+            <svg
+              width={32}
+              height={23}
+              viewBox="0 0 29 20"
+              className={styles.CareerPath__YouTubeIcon}
+            >
+              <use href="#youtube" />
+            </svg>
+          </Link>
+        </div>
+
         <div className={styles.CareerPath__SurveyLink}>
           <Link
             href="https://docs.google.com/document/d/e/2PACX-1vRZv3ro50YWS5LdR3PSGB3b93omPY854misnktTRAOZ7xgIOj9MRQs4TgybkO3kJLSDzUXiQEoDDaJ4/pub"


### PR DESCRIPTION
Closes #31

## 概要
Career Path ページに、SiiD 公式 YouTube チャンネル（https://www.youtube.com/@programming-siid）への導線ボタンを追加しました。

## 変更内容
- ボタンテキスト: 「その他の受講生様実績はこちら」
- 設置位置: 「過去の卒業生のアンケート内容はこちら」ボタンの**前**
- 既存アンケートリンクのスタイル（ダーク背景のピル型ボタン）を踏襲し、末尾に YouTube アイコン（`#youtube` スプライト）を配置
- SP / PC 両対応（アイコンサイズ・下マージンをレスポンシブ調整）

## 変更ファイル
- `src/components/CareerPath/CareerPathList/CareerPathList.tsx`
- `src/components/CareerPath/CareerPathList/CareerPathList.module.css`

## 確認方法
1. `npm run dev` で起動し `/career-path/1` を開く
2. ページ下部、アンケートボタンの上に YouTube ボタンが表示される
3. クリックで `@programming-siid` チャンネルが別タブで開く

## 検証済み
- `npm run lint` ✔ エラーなし
- `npm run typecheck` ✔ エラーなし
- ローカルブラウザで SP（390px）/ PC（1440px）両方の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)