### PR TITLE
feat: /counseling をコンバージョン特化レイアウトに変更 (#42)

### DIFF
--- a/docs/spec/03_pages.md
+++ b/docs/spec/03_pages.md
@@ -44,6 +44,12 @@
   2. **予約完了ページ `/counseling/complete`**(`src/app/(LowerPages)/counseling/complete/`)= サンクス画面。3 ステップ案内 + TOP 導線。`robots: noindex`
 - **アナリティクスタグの引き継ぎは本 PR のスコープ外**(サイト全体の別 Issue で対応)。参考として本番ページで検出したタグ: GA4 `G-54L1JQ7Q7V` / GTM `GTM-58D75LLL`・`GTM-NWT5NTNS`・`GTM-PCDDS7MV`(いずれが SiiD 専用か bug-fix.org 共通かは要確認)
 - Complete ページへの遷移は Jicoo 側のリダイレクト先設定が別途必要(予約完了後に `/counseling/complete` へ飛ばす)。未設定でもページ単体は成立する。
+- **コンバージョン特化レイアウト【対応済み 2026-07 / Issue #42】**: SEO コンサルタントの助言(フォームページから離脱リンクを排除すると CVR が改善する)に基づき、`/counseling` のみ共通クロームを簡易表示に変更。対象パスは `src/constants/conversionFocusedPages.ts` で一元管理し、各コンポーネントが `usePathname()` で判定する。
+  - PC ナビ(`NavigationPcLower`): グローバルメニュー非表示・SiiD ロゴのリンクを解除(ロゴ表示は維持)
+  - SP ナビ(`NavigationSp`): ハンバーガーメニュー・CONTACT ボタンを出さず、ロゴのみの固定ピルを表示
+  - フッター(`Footer` / `FooterMenu`): コピーライトのみ表示(メニュー・SNS・プライバシーポリシー等のリンク、CONTACT ボタン、ページトップも非表示)
+  - パンくずも TOP へのリンクを含むため `/counseling` からは削除(Issue 記載外だが趣旨に合わせた対応)
+  - `/counseling/complete` は対象外(通常レイアウトのまま)
 
 ## 3-4. 404 Not Found【実装済み 2026-07 / Issue #24】
 

--- a/src/app/(LowerPages)/counseling/page.tsx
+++ b/src/app/(LowerPages)/counseling/page.tsx
@@ -2,9 +2,6 @@ import { Metadata } from 'next';
 
 import Script from 'next/script';
 
-import Breadcrumb, {
-  BreadcrumbProps,
-} from '@/components/Breadcrumb/Breadcrumb';
 import ContentsArea from '@/components/ContentsArea/ContentsArea';
 import Benefits from '@/components/Counseling/Benefits/Benefits';
 import Headline from '@/components/Headline/Headline';
@@ -15,11 +12,6 @@ import styles from './Counseling.module.css';
 
 export const metadata: Metadata = buildPageMetadata(pages.counseling);
 
-const breadcrumb: BreadcrumbProps[] = [
-  { title: pages.index.name.ja, url: pages.index.url },
-  { title: pages.counseling.name.ja, url: pages.counseling.url },
-];
-
 export default function Courses() {
   return (
     <div className={styles.Courses}>
@@ -28,7 +20,7 @@ export default function Courses() {
         title={pages.counseling.name.en}
         description={handleStringHTML(pages.counseling.description, true)}
       />
-      <Breadcrumb breadcrumb={breadcrumb} />
+      {/* パンくずは TOP へのリンクを含むため、コンバージョン特化ページでは出さない (Issue #42) */}
       <ContentsArea>
         <Benefits />
         <div className={styles.Counseling}>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
+
+import { isConversionFocusedPage } from '@/constants/conversionFocusedPages';
+
 import useIsPc from '../../hooks/useIsPc';
 import ContactButton from '../ContactButton/ContactButton';
 import Corner, { CornerPosition } from '../Corner/Corner';
@@ -10,6 +14,7 @@ import Pagetop from './Pagetop/Pagetop';
 
 export default function Footer() {
   const isPc = useIsPc();
+  const isConversionFocused = isConversionFocusedPage(usePathname());
 
   return (
     <footer className={styles.Footer}>
@@ -33,13 +38,17 @@ export default function Footer() {
 
       <div className={styles.Footer__Container}>
         <div className={styles.Footer__Inner}>
-          <FooterMenu />
-          <div className={styles.Footer__ContactButton}>
-            <ContactButton modifier="isFooter" />
-          </div>
-          <div className={styles.Footer__Pagetop}>
-            <Pagetop />
-          </div>
+          <FooterMenu copyrightOnly={isConversionFocused} />
+          {!isConversionFocused && (
+            <>
+              <div className={styles.Footer__ContactButton}>
+                <ContactButton modifier="isFooter" />
+              </div>
+              <div className={styles.Footer__Pagetop}>
+                <Pagetop />
+              </div>
+            </>
+          )}
         </div>
       </div>
     </footer>

--- a/src/components/Footer/FooterMenu/FooterMenu.module.css
+++ b/src/components/Footer/FooterMenu/FooterMenu.module.css
@@ -161,4 +161,9 @@
         left: 30px;
         bottom: 30px;
     }
+    /* コピーライトのみ表示時(コンバージョン特化ページ)は絶対配置を解除して中央寄せ */
+    .FooterMenu__Copyright.isStatic {
+        position: static;
+        margin: 0 auto;
+    }
 }

--- a/src/components/Footer/FooterMenu/FooterMenu.tsx
+++ b/src/components/Footer/FooterMenu/FooterMenu.tsx
@@ -9,7 +9,18 @@ import { snsFooterItems } from '@/constants/snsItems';
 import styles from './FooterMenu.module.css';
 
 
-export default function FooterMenu() {
+export default function FooterMenu({ copyrightOnly = false }: { copyrightOnly?: boolean }) {
+  const copyright = (
+    <small className={`${styles.FooterMenu__Copyright} ${copyrightOnly ? styles.isStatic : ''}`}>
+             Copyright (&copy;) BugFix All Rights Reserved.
+    </small>
+  );
+
+  // コンバージョン特化ページ(Issue #42)ではリンク要素をすべて出さない
+  if (copyrightOnly) {
+    return <div className={styles.FooterMenu}>{copyright}</div>;
+  }
+
   return (
     <div className={styles.FooterMenu}>
       <div className={styles.FooterMenu__Landmark}>
@@ -63,9 +74,7 @@ export default function FooterMenu() {
           <Link href="https://bug-fix.org" target="_blank">運営会社</Link>
         </li>
       </ul>
-      <small className={styles.FooterMenu__Copyright}>
-             Copyright (&copy;) BugFix All Rights Reserved.
-      </small>
+      {copyright}
     </div>
   );
 }

--- a/src/components/Navigation/NavigationPcLower/NavigationPcLower.tsx
+++ b/src/components/Navigation/NavigationPcLower/NavigationPcLower.tsx
@@ -2,9 +2,11 @@
 
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import Corner, { CornerPosition } from '@/components/Corner/Corner';
 import Logo from '@/components/Logo/Logo';
+import { isConversionFocusedPage } from '@/constants/conversionFocusedPages';
 import useScroll from '@/hooks/useScroll';
 
 import Menu from '../Menu/Menu';
@@ -14,6 +16,7 @@ import styles from './NavigationPcLower.module.css';
 export default function NavigationPcLower() {
 
   const scrollY = useScroll();
+  const isConversionFocused = isConversionFocusedPage(usePathname());
 
   return (
     <nav className={`${styles.NavigationPcLower} ${scrollY > 0 ? styles.isScrolling : ''}`}>
@@ -22,17 +25,23 @@ export default function NavigationPcLower() {
           <Corner top="0" right="0" position={CornerPosition.TOP_RIGHT} />
         </div>
         <div className={styles.NavigationPcLower__logo}>
-          <Link href="/">
+          {isConversionFocused ? (
             <Logo width={102} height={25} fill="#fff" />
-          </Link>
+          ) : (
+            <Link href="/">
+              <Logo width={102} height={25} fill="#fff" />
+            </Link>
+          )}
           <div className={styles.NavigationPcLower__Corner}>
             <Corner bottom="-20px" left="0" position={CornerPosition.TOP_LEFT} />
             <Corner top="0" right="-20px" position={CornerPosition.TOP_LEFT} />
           </div>
         </div>
-        <div className={styles.NavigationPcLower__Menu}>
-          <Menu modifierClass="isLower" />
-        </div>
+        {!isConversionFocused && (
+          <div className={styles.NavigationPcLower__Menu}>
+            <Menu modifierClass="isLower" />
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/src/components/Navigation/NavigationSp/NavigationSp.module.css
+++ b/src/components/Navigation/NavigationSp/NavigationSp.module.css
@@ -76,6 +76,10 @@
   transform-origin: center;
   margin: 0 auto;
 }
+/* コンバージョン特化ページ(ロゴのみ・非インタラクティブ)ではポインターを出さない */
+.NavigationSp__Button.isLogoOnly {
+  cursor: default;
+}
 .NavigationSp__ButtonBack {
   position: fixed;
   z-index: calc(var(--maxZ) - 3);

--- a/src/components/Navigation/NavigationSp/NavigationSp.tsx
+++ b/src/components/Navigation/NavigationSp/NavigationSp.tsx
@@ -2,15 +2,35 @@
 
 import React, { useState } from 'react';
 
+import { usePathname } from 'next/navigation';
+
 import ContactButton from '@/components/ContactButton/ContactButton';
 import Logo from '@/components/Logo/Logo';
 import HamburgerMenu from '@/components/Navigation/HamburgerMenu/HamburgerMenu';
 import Menu from '@/components/Navigation/Menu/Menu';
+import { isConversionFocusedPage } from '@/constants/conversionFocusedPages';
 
 import styles from './NavigationSp.module.css';
 
 function NavigationSp() {
   const [isActive, setIsActive] = useState(false);
+  const isConversionFocused = isConversionFocusedPage(usePathname());
+
+  if (isConversionFocused) {
+    return (
+      <nav className={styles.NavigationSp}>
+        <div className={styles.NavigationSp__ButtonContainer}>
+          <div className={styles.NavigationSp__Button}>
+            <div className={styles.NavigationSp__Item}>
+              <Logo />
+            </div>
+          </div>
+        </div>
+        <div className={styles.NavigationSp__ButtonBack} />
+      </nav>
+    );
+  }
+
   return (
     <nav className={`${styles.NavigationSp} ${isActive ? styles.isActive : ''}`}>
       <div className={styles.NavigationSp__Container}>

--- a/src/components/Navigation/NavigationSp/NavigationSp.tsx
+++ b/src/components/Navigation/NavigationSp/NavigationSp.tsx
@@ -20,7 +20,7 @@ function NavigationSp() {
     return (
       <nav className={styles.NavigationSp}>
         <div className={styles.NavigationSp__ButtonContainer}>
-          <div className={styles.NavigationSp__Button}>
+          <div className={`${styles.NavigationSp__Button} ${styles.isLogoOnly}`}>
             <div className={styles.NavigationSp__Item}>
               <Logo />
             </div>

--- a/src/constants/conversionFocusedPages.ts
+++ b/src/constants/conversionFocusedPages.ts
@@ -1,0 +1,6 @@
+// コンバージョン集中のため共通クローム(グローバルナビ・フッターメニュー)を
+// 簡易表示に切り替えるページ。ロゴはリンクなし・フッターはコピーライトのみ (Issue #42)
+export const CONVERSION_FOCUSED_PATHS = ['/counseling'];
+
+export const isConversionFocusedPage = (pathname: string) =>
+  CONVERSION_FOCUSED_PATHS.includes(pathname);


### PR DESCRIPTION
## 概要
SEOコンサルタントの助言(フォームページから離脱リンクを排除するとCVRが改善)に基づき、`/counseling` のみ共通レイアウトを簡易表示に変更する。

Closes #42

## 変更内容
- **PCナビ (`NavigationPcLower`)**: グローバルメニュー非表示・SiiDロゴのリンク解除(ロゴ表示は維持)
- **SPナビ (`NavigationSp`)**: ハンバーガーメニュー・CONTACTボタンを出さず、ロゴのみの固定ピルを表示
- **フッター (`Footer` / `FooterMenu`)**: コピーライトのみ表示(メニュー・SNS・プライバシーポリシー/運営会社リンク・CONTACTボタン・Pagetopを非表示)
- **パンくず**: TOPへのリンクを含むため `/counseling` から削除 ※Issue記載外だが「他のページに行かせない」という趣旨に合わせた対応。不要なら該当コミットのこの部分のみ戻せます
- 対象パスは `src/constants/conversionFocusedPages.ts` で一元管理し、各コンポーネントが `usePathname()` で判定
- `/counseling/complete` は対象外(通常レイアウトのまま)
- `docs/spec/03_pages.md` に仕様を反映

## 検証
- `npm run lint` / `npm run typecheck` / `npm run build` すべて成功
- プリレンダー済み HTML で確認:
  - `/counseling`: ナビメニュー・フッターメニュー・ハンバーガー・パンくず・`href="/"` がすべて 0 件、コピーライトのみ残存
  - `/`・`/courses`・`/counseling/complete`: 通常レイアウトのまま(影響なし)

## 備考
PR #41 (Issue #40) が `(Main)`/`(Lp)` へのディレクトリ再編を含むため、先に #41 をマージした場合は本PRでファイル移動のコンフリクト解消が必要になる可能性があります(変更自体はコンポーネント内で完結)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)