### PR TITLE
fix: /counseling のヘッダーを丸ごと非表示に変更 (#42 フォローアップ)

### DIFF
--- a/docs/spec/03_pages.md
+++ b/docs/spec/03_pages.md
@@ -45,8 +45,7 @@
 - **アナリティクスタグの引き継ぎは本 PR のスコープ外**(サイト全体の別 Issue で対応)。参考として本番ページで検出したタグ: GA4 `G-54L1JQ7Q7V` / GTM `GTM-58D75LLL`・`GTM-NWT5NTNS`・`GTM-PCDDS7MV`(いずれが SiiD 専用か bug-fix.org 共通かは要確認)
 - Complete ページへの遷移は Jicoo 側のリダイレクト先設定が別途必要(予約完了後に `/counseling/complete` へ飛ばす)。未設定でもページ単体は成立する。
 - **コンバージョン特化レイアウト【対応済み 2026-07 / Issue #42】**: SEO コンサルタントの助言(フォームページから離脱リンクを排除すると CVR が改善する)に基づき、`/counseling` のみ共通クロームを簡易表示に変更。対象パスは `src/constants/conversionFocusedPages.ts` で一元管理し、各コンポーネントが `usePathname()` で判定する。
-  - PC ナビ(`NavigationPcLower`): グローバルメニュー非表示・SiiD ロゴのリンクを解除(ロゴ表示は維持)
-  - SP ナビ(`NavigationSp`): ハンバーガーメニュー・CONTACT ボタンを出さず、ロゴのみの固定ピルを表示
+  - PC ナビ(`NavigationPcLower`)・SP ナビ(`NavigationSp`): ヘッダーごと非表示(`return null`)。当初はリンクなしロゴのみ残す実装だったが、見た目の違和感からオーナー指示で丸ごと非表示に変更(2026-07)
   - フッター(`Footer` / `FooterMenu`): コピーライトのみ表示(メニュー・SNS・プライバシーポリシー等のリンク、CONTACT ボタン、ページトップも非表示)
   - パンくずも TOP へのリンクを含むため `/counseling` からは削除(Issue 記載外だが趣旨に合わせた対応)
   - `/counseling/complete` は対象外(通常レイアウトのまま)

--- a/src/components/Navigation/NavigationPcLower/NavigationPcLower.tsx
+++ b/src/components/Navigation/NavigationPcLower/NavigationPcLower.tsx
@@ -18,6 +18,11 @@ export default function NavigationPcLower() {
   const scrollY = useScroll();
   const isConversionFocused = isConversionFocusedPage(usePathname());
 
+  // コンバージョン特化ページ(Issue #42)ではナビゲーション自体を出さない
+  if (isConversionFocused) {
+    return null;
+  }
+
   return (
     <nav className={`${styles.NavigationPcLower} ${scrollY > 0 ? styles.isScrolling : ''}`}>
       <div className={styles.NavigationPcLower__Container}>
@@ -25,23 +30,17 @@ export default function NavigationPcLower() {
           <Corner top="0" right="0" position={CornerPosition.TOP_RIGHT} />
         </div>
         <div className={styles.NavigationPcLower__logo}>
-          {isConversionFocused ? (
+          <Link href="/">
             <Logo width={102} height={25} fill="#fff" />
-          ) : (
-            <Link href="/">
-              <Logo width={102} height={25} fill="#fff" />
-            </Link>
-          )}
+          </Link>
           <div className={styles.NavigationPcLower__Corner}>
             <Corner bottom="-20px" left="0" position={CornerPosition.TOP_LEFT} />
             <Corner top="0" right="-20px" position={CornerPosition.TOP_LEFT} />
           </div>
         </div>
-        {!isConversionFocused && (
-          <div className={styles.NavigationPcLower__Menu}>
-            <Menu modifierClass="isLower" />
-          </div>
-        )}
+        <div className={styles.NavigationPcLower__Menu}>
+          <Menu modifierClass="isLower" />
+        </div>
       </div>
     </nav>
   );

--- a/src/components/Navigation/NavigationSp/NavigationSp.module.css
+++ b/src/components/Navigation/NavigationSp/NavigationSp.module.css
@@ -76,10 +76,6 @@
   transform-origin: center;
   margin: 0 auto;
 }
-/* コンバージョン特化ページ(ロゴのみ・非インタラクティブ)ではポインターを出さない */
-.NavigationSp__Button.isLogoOnly {
-  cursor: default;
-}
 .NavigationSp__ButtonBack {
   position: fixed;
   z-index: calc(var(--maxZ) - 3);

--- a/src/components/Navigation/NavigationSp/NavigationSp.tsx
+++ b/src/components/Navigation/NavigationSp/NavigationSp.tsx
@@ -16,19 +16,9 @@ function NavigationSp() {
   const [isActive, setIsActive] = useState(false);
   const isConversionFocused = isConversionFocusedPage(usePathname());
 
+  // コンバージョン特化ページ(Issue #42)ではナビゲーション自体を出さない
   if (isConversionFocused) {
-    return (
-      <nav className={styles.NavigationSp}>
-        <div className={styles.NavigationSp__ButtonContainer}>
-          <div className={`${styles.NavigationSp__Button} ${styles.isLogoOnly}`}>
-            <div className={styles.NavigationSp__Item}>
-              <Logo />
-            </div>
-          </div>
-        </div>
-        <div className={styles.NavigationSp__ButtonBack} />
-      </nav>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
## 概要
Issue #42 のフォローアップ。`/counseling` でロゴのみのヘッダー(PC/SPナビ)を残していたが、見た目に違和感があるとのオーナー指摘により、ヘッダーごと非表示に変更する。

関連: #42 (クローズ済み) / PR #43

## 変更内容
- `NavigationPcLower` / `NavigationSp`: コンバージョン特化ページでは `return null`(ロゴ含め完全非表示)
- 不要になった `isLogoOnly` スタイルを削除
- `docs/spec/03_pages.md` の該当記述を更新

## 検証
- `npm run lint` / `npm run typecheck` / `npm run build` 成功
- プリレンダー HTML で `/counseling` に NavigationSp / NavigationPcLower のマークアップが 0 件、コピーライトのみ残存を確認
- `/courses` 等の他ページは通常レイアウトのまま(影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)