### PR TITLE
docs: DNS 移管手順書を追加 (#45)

### DIFF
--- a/docs/spec/06_migration.md
+++ b/docs/spec/06_migration.md
@@ -61,6 +61,8 @@ graph TD
 - `bug-fix.org`(apex)および `www` を Cloudflare 管理へ移管し、**proxied(orange-cloud)** にする。
 - `blog.bug-fix.org`(Vercel)・`siid.bug-fix.org`(Utage)は**現状維持**(DNS-only / プロキシ対象外)。既存挙動を変えない。
 
+移管の具体的な手順・現行レコード一覧・注意点は **[§10 DNS 移管手順書](#10-dns-移管手順書issue-45)** を参照。
+
 ### 3.2 Cloudflare Worker(ルーティング)
 
 Redirect Rule ではなく **Worker** を用いる。URL を `bug-fix.org/siid/...` のまま保ちつつ別オリジン(Vercel)の内容を返す**リバースプロキシ**が必要なため(Redirect Rule では URL が変わってしまう)。
@@ -103,9 +105,10 @@ Redirect Rule ではなく **Worker** を用いる。URL を `bug-fix.org/siid/.
 
 各ステップ後に回帰確認を行い、問題なければ次へ進む。
 
-- **Pre. DNS 移管**
+- **Pre. DNS 移管**(Issue #45)
   - 現行 DNS の TTL を短縮 → ネームサーバを Cloudflare へ切替 → apex を proxied 化。
   - この時点では Worker 未設定 or 全パス GitHub Pages のままとし、**挙動が現行と変わらない**ことを確認。
+  - **手順の詳細・現行レコード一覧・失敗しやすい点は [§10](#10-dns-移管手順書issue-45) にまとめてある。メール(Google Workspace)を止めないため必ず参照すること。**
 - **Step1. 新アプリ本番デプロイ**
   - `siid-web` を Vercel に `basePath: '/siid'` で本番デプロイ。Vercel の直 URL / プレビューで単体動作確認。
 - **Step2. `/siid` を新アプリへ切替**
@@ -157,3 +160,97 @@ Redirect Rule ではなく **Worker** を用いる。URL を `bug-fix.org/siid/.
 - GA4 / GTM 各タグの SiiD 固有・共有の切り分けと引き継ぎ範囲
 - `/siid/counseling` の Jicoo ウィジェット(`event_types/dPvwnhRYxhQB`, [03_pages.md](./03_pages.md) 参照)を本番でそのまま共有してよいか
 - 実装スコープ(basePath 設定・`redirects()`・Cloudflare Worker・DNS 移管・Vercel 本番設定)を扱う後続 Issue の起票
+
+---
+
+## 10. DNS 移管手順書(Issue #45)
+
+カットオーバー Pre(§5)の実作業手順。**この作業はドメイン管理画面での操作であり、リポジトリのコード変更を伴わない。**
+
+### 10.1 前提情報(2026-08 時点の実測)
+
+| 項目 | 値 |
+|---|---|
+| レジストラ | **Squarespace Domains II LLC**(https://domains.squarespace.com) — **ネームサーバ変更はここで行う** |
+| 現行 DNS ホスト | **Google Cloud DNS**(`ns-cloud-b1〜b4.googledomains.com`) — レコードの現物はここにある |
+| ドメイン有効期限 | 2027-03-13 |
+| ドメインステータス | `clientTransferProhibited`(レジストラ移管ロック)。**ネームサーバ変更にはロック解除は不要** |
+
+> レジストラ(Squarespace)と DNS ホスト(Google Cloud DNS)が別である点に注意。**移管するのはネームサーバの向き先**であり、ドメインそのものの移管(レジストラ変更)は行わない。
+
+### 10.2 現行レコード一覧(Cloudflare で再現すべき全レコード)
+
+**移管の最大のリスクはレコードの取りこぼし。特に MX / SPF / DKIM / DMARC を落とすとメールが停止する。**
+
+| 名前 | 種別 | 値 | TTL | Cloudflare での設定 |
+|---|---|---|---|---|
+| `bug-fix.org` | A | `185.199.108.153` / `185.199.109.153` / `185.199.110.153` / `185.199.111.153` | 3600 | **Proxied**(GitHub Pages) |
+| `bug-fix.org` | AAAA | `2606:50c0:8000::153` / `8001::153` / `8002::153` / `8003::153` | — | **Proxied**(GitHub Pages) |
+| `www` | CNAME | `seito-developer.github.io` | 14400 | **Proxied** |
+| `blog` | CNAME | `cc021d3efa3de4c8.vercel-dns-017.com` | 14400 | **DNS only**(Vercel) |
+| `siid` | CNAME | `dns.utage-domain.com` | 14400 | **DNS only**(Utage) |
+| `bug-fix.org` | MX | `1 aspmx.l.google.com` / `5 alt1` / `5 alt2` / `10 alt3` / `10 alt4`(すべて `.aspmx.l.google.com`) | 14400 | **DNS only**(Google Workspace) |
+| `bug-fix.org` | TXT (SPF) | `v=spf1 include:_spf.google.com +mx include:myasp.jp ~all` | 14400 | DNS only |
+| `_dmarc` | TXT | `v=DMARC1; p=none;` | 14400 | DNS only |
+| `google._domainkey` | TXT (DKIM) | `v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl6IKssV3gJzyz6WlqC+hX9GZNdxSgPniUH+Xpa2OB2SSm0sSC77e4CzvxLFr8eEfIU4QyQ2uaoNZaFKs5vDjFrsfcnme9DfERp9pyUXapTu1dzFrUpfUpwx8w+ZWPerYRHO+JMk/MLnYxZepbarQuDDl+y8BguXUn0aCrGlbgFkUaZEsOs2tfnnuT4zUFNq1OtqaVxTPRe5/DJGSHANDaBfQwjoJEHtHqKvjvYkRET0KwB6TzrKdQsUmVYSGBZrcNccgalm9bPuHwBSTPR00eFdJIrXwGHOa4y1OnAIVU/T9DjVzn9Mp8ecMfWUSepry8WCcrPl7zHmhYua753t6jQIDAQAB` | 14400 | DNS only |
+
+- CAA レコードは未設定。
+- 上記は外部から DNS を引いた結果。**作業前に Google Cloud DNS の管理画面でゾーンをエクスポートし、非公開・未使用のレコードが他に無いか必ず突き合わせること**(外部からは存在を知り得ないサブドメインがある可能性がある)。
+
+### 10.3 失敗しやすい点(必読)
+
+1. **SSL/TLS モードを「フル(Full)」にする。** Cloudflare の既定が「フレキシブル」だと、GitHub Pages が HTTPS へリダイレクトするためリダイレクトループ(ERR_TOO_MANY_REDIRECTS)になる。なお「フル(厳密)」は、プロキシ配下では GitHub Pages の証明書更新が失敗しうるため当面避け、**「フル」**とする。
+2. **`siid.bug-fix.org` は絶対に proxied にしない。** 向き先の Utage 自体が Cloudflare 配下(解決先が `104.26.x` / `172.67.x`)のため、プロキシすると Cloudflare の多重プロキシとなり **Error 1000: DNS points to prohibited IP** で機能停止する。
+3. **`blog.bug-fix.org`(Vercel)も DNS only。** Vercel 側で証明書を管理しているため、プロキシすると証明書エラーの原因になる。
+4. **DKIM の TXT は 1 レコードとして登録する。** DNS 上は 255 文字ごとに分割されて見えるが、Cloudflare には分割せず全文を 1 つの値として入力する(分割して登録すると DKIM 検証が失敗する)。
+5. **Cloudflare の自動レコードインポートは取りこぼす前提で確認する。** ネームサーバ切替前に、§10.2 の全レコードが Cloudflare 側に揃っているか目視で照合する。
+6. **Google Cloud DNS のゾーンは削除しない。** ロールバック時にネームサーバを戻すだけで復旧できるようにするため、移管の成功を確認するまで残す。
+7. **TTL 短縮は切替の 4 時間以上前に行う。** 現行 TTL が 14400 秒(4 時間)のため、短縮しても既存キャッシュが切れるまでその時間がかかる。
+
+### 10.4 作業手順
+
+1. **オーナー承認**(§9 の未確定事項)。apex を Cloudflare 配下に置くことの合意を得る。
+2. **Google Cloud DNS でゾーンをエクスポート**し、§10.2 と突き合わせて全レコードを確定させる。
+3. **Google Cloud DNS 側で全レコードの TTL を 300 秒へ短縮** → **4 時間以上待つ**(既存キャッシュの失効待ち)。
+4. **Cloudflare にサイトを追加**し、§10.2 のレコードを登録。プロキシ状態(orange/grey)を表の指定どおりに設定する。
+5. **SSL/TLS を「フル」に設定**(§10.3-1)。
+6. **Squarespace のレジストラ管理画面でネームサーバを Cloudflare のものへ変更**。
+7. **反映を確認**し、§10.5 の検証を実施する。
+8. この時点では **Worker を設定しない**(全パスが従来どおり GitHub Pages / Vercel / Utage へ向く状態)。
+
+### 10.5 検証(移管前後で同一になること)
+
+移管前の実測ベースライン(2026-08 時点):
+
+| URL | 移管前の応答 |
+|---|---|
+| `https://bug-fix.org/` | 200 |
+| `https://bug-fix.org/siid` | 200 |
+| `https://bug-fix.org/siid/lp-1` | 200 |
+| `https://blog.bug-fix.org/` | 200 |
+| `https://siid.bug-fix.org/` | 404(移管前から 404。**悪化していないことの確認用**) |
+
+```bash
+# HTTP 応答の比較
+for u in https://bug-fix.org/ https://bug-fix.org/siid https://bug-fix.org/siid/lp-1 \
+         https://blog.bug-fix.org/ https://siid.bug-fix.org/; do
+  echo "$(curl -sS -o /dev/null -w '%{http_code}' -L "$u") $u"
+done
+
+# ネームサーバの切替確認
+dig +short NS bug-fix.org
+
+# メール系レコードが生きているか（最重要）
+dig +short MX bug-fix.org
+dig +short TXT bug-fix.org
+dig +short TXT _dmarc.bug-fix.org
+dig +short TXT google._domainkey.bug-fix.org
+```
+
+- **メールの実送受信テスト**を必ず行う(外部アドレスとの往復)。DNS 上のレコード存在だけでは不十分。
+- Google Workspace 管理コンソールでドメインの状態にエラーが出ていないか確認する。
+
+### 10.6 ロールバック
+
+- **Squarespace でネームサーバを `ns-cloud-b1〜b4.googledomains.com` に戻す。** Google Cloud DNS のゾーンを残しておけば即座に復旧できる(§6)。
+- TTL を短縮済みのため反映は速いが、ネームサーバ自体の変更はレジストリの TTL(通常 24〜48 時間)に従うため、**即時には戻らない場合がある**点に注意。この意味でも「切替前の照合」を厚くしておくことが重要。


### PR DESCRIPTION
Refs #45（管理画面での実作業が残るため、本 PR では Issue をクローズしない）

## 背景

Issue #45（DNS を Cloudflare へ移管）は Squarespace と Cloudflare の管理画面での操作が主体で、リポジトリのコード変更を伴いません。そこで、**作業を安全に実施するための手順書**を仕様書に追加しました。

## 調査でわかった重要な事実

**`bug-fix.org` は Google Workspace でメールを運用しています**（MX 5件 + SPF + DKIM + DMARC）。ネームサーバ移管でこれらを取りこぼすと**メールが停止**します。今回の移管における最大のリスクで、手順書の中心に据えました。

また、レジストラと DNS ホストが別であることも判明しました。

| 項目 | 値 |
|---|---|
| レジストラ | Squarespace Domains II LLC（**ネームサーバ変更はここ**） |
| 現行 DNS ホスト | Google Cloud DNS（`ns-cloud-b1〜b4.googledomains.com`） |
| ドメインロック | `clientTransferProhibited`（NS 変更には解除不要） |

## 追加した内容（06_migration.md §10）

- **現行レコード全件の一覧**（A / AAAA / CNAME / MX / SPF / DKIM / DMARC）と、Cloudflare でのプロキシ設定（orange / grey）の指定
- **失敗しやすい点**
  - SSL/TLS を「フル」にする（既定のフレキシブルだと GitHub Pages とリダイレクトループ）
  - `siid.bug-fix.org` は proxied 禁止。Utage 自体が Cloudflare 配下（`104.26.x`）のため多重プロキシで Error 1000 になる
  - DKIM の TXT は分割せず 1 レコードで登録する
  - TTL 短縮は切替の 4 時間以上前（現行 TTL が 14400 秒のため）
  - Cloudflare の自動インポートは取りこぼす前提で照合する
- **作業手順**（承認 → ゾーンエクスポート → TTL 短縮 → Cloudflare 登録 → SSL 設定 → NS 変更 → 検証）
- **移管前の応答をベースラインとして記録**し、前後比較できるようにしました

| URL | 移管前 |
|---|---|
| `bug-fix.org/` | 200 |
| `bug-fix.org/siid` | 200 |
| `bug-fix.org/siid/lp-1` | 200 |
| `blog.bug-fix.org/` | 200 |
| `siid.bug-fix.org/` | 404（元から 404。悪化していないことの確認用） |

- **検証コマンド**（HTTP 応答比較・NS 確認・メール系レコード確認）と**ロールバック手順**

## 確認方法

`npm run lint` / `npm run typecheck` パス（ドキュメントのみの変更）。レコードの値はすべて `dig` / `whois` による実測です。

## 次のアクション

手順書 §10.4 の作業（オーナー承認 → Google Cloud DNS のゾーンエクスポート → TTL 短縮 → Cloudflare 登録 → NS 変更）は管理画面での操作となるため、実施をお願いします。特に **ステップ2（ゾーンエクスポートと照合）** は、外部から観測できない非公開サブドメインを拾うために必須です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)