### PR TITLE
fix: Newsセクションの表示形式修正とTechブログリンク削除 (#55)

### DIFF
--- a/docs/spec/01_project-overview.md
+++ b/docs/spec/01_project-overview.md
@@ -39,11 +39,14 @@ ITエンジニア転職 × 生成AI特化プログラミングスクール「Sii
 | `/counseling-complete-lp-1` | 実装済み(2026-07 / Issue #40)。旧サイトから移植した申込完了ページ(noindex)。OpenAI Ads CV計測 `appointment_scheduled` を発火 | Figma 対応なし |
 | `/white-paper` | 実装済み(2026-07 / Issue #40)。旧サイトから移植した資料請求ページ(公式LINE誘導) | Figma 対応なし |
 
-## TOPページ News セクション（microCMS 連携・Issue #30）
+## TOPページ News セクション（microCMS 連携・Issue #30 / #55）
 
 - SiiD BLOG（microCMS）の `blog` エンドポイントから「コラム」カテゴリの最新記事を取得して表示。記事クリックで該当記事（`https://blog.bug-fix.org/blog/{id}`）へ遷移。
 - 取得ロジックは `src/lib/getNews.ts`（サーバー側実行）。`categories[contains]column` で絞り込み、`publishedAt` 降順で最大3件。ISR で 600 秒ごとに再検証。カテゴリID `column` は変更予定がないため定数で固定。
-- `News.tsx` は async Server Component（取得担当）、スワイプ/矢印カルーセルUXは `NewsCarousel.tsx`（Client Component）に分離。
+- `News.tsx` は props で記事を受け取る Server Component、スワイプ/矢印カルーセルUXは `NewsCarousel.tsx`（Client Component）に分離。取得は `src/app/(Main)/page.tsx` が `getNews()` を呼んで行う。
+- 表示形式は **`yyyy/mm/dd | title`**（`NewsPost.tsx`）。`|` は `.NewsPost__date::after` の擬似要素、タイトルは 2 行で省略。
+  - 日付は `Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', ... })` で整形する。`publishedAt` は UTC のため、タイムゾーンを固定しないとサーバー（UTC）とクライアント（JST）で表示がズレて Hydration Error になる。
+- 「SiiD Techブログ」への導線リンクは Issue #55 で削除済み（再追加しないこと）。
 - 環境変数（サーバー専用・`.env.local` / Vercel に設定。`.env.example` 参照）:
 
   | 変数 | 説明 |
@@ -53,6 +56,13 @@ ITエンジニア転職 × 生成AI特化プログラミングスクール「Sii
 
 - `blog` エンドポイントの `categories` は複数参照フィールドのため、絞り込みは `equals` ではなく `contains` を使う。
 - 環境変数未設定・取得失敗時は空配列を返し、News は「現在お知らせはありません。」を表示（ページ全体は落とさない）。
+- **切り分け方法（Issue #55）**: 失敗ケースは全て同じ「現在お知らせはありません。」になるため、`getNews()` は原因を `console.error` / `console.warn` に出力する。表示されない場合は **Vercel の Runtime Logs** を確認する。
+  | ログ | 原因 |
+  |------|------|
+  | `microCMS の環境変数が未設定` | Vercel の Environment Variables 未登録、または対象環境（Production / Preview）に未設定 |
+  | `microCMS から 0 件が返りました` | `filters` の不一致（カテゴリID・フィールド名） |
+  | `microCMS からの記事取得に失敗しました` | エンドポイント名の誤り（404）・API キーの権限不足（401）・タイムアウト |
+- **環境変数を追加・変更したら再デプロイが必要**。TOPページは静的生成されるため、環境変数が無い状態でビルドされると `getNews()` が fetch 前に return し、ISR の再検証も登録されない＝空のページが恒久的にキャッシュされる。
 
 ## Figma デザインデータ
 

--- a/docs/spec/01_project-overview.md
+++ b/docs/spec/01_project-overview.md
@@ -62,7 +62,8 @@ ITエンジニア転職 × 生成AI特化プログラミングスクール「Sii
   | `microCMS の環境変数が未設定` | Vercel の Environment Variables 未登録、または対象環境（Production / Preview）に未設定 |
   | `microCMS から 0 件が返りました` | `filters` の不一致（カテゴリID・フィールド名） |
   | `microCMS からの記事取得に失敗しました` | エンドポイント名の誤り（404）・API キーの権限不足（401）・タイムアウト |
-- **環境変数を追加・変更したら再デプロイが必要**。TOPページは静的生成されるため、環境変数が無い状態でビルドされると `getNews()` が fetch 前に return し、ISR の再検証も登録されない＝空のページが恒久的にキャッシュされる。
+- **環境変数を追加・変更したら再デプロイが必要**（Vercel の環境変数は既存デプロイには反映されない）。
+- 再検証は `getNews()` 内の fetch だけでなく、`src/app/(Main)/page.tsx` の `export const revalidate = 600` でもルート単位に指定する。環境変数未設定などで fetch 自体が実行されないとページが完全な静的扱いになり二度と再生成されないため（Issue #55）。
 
 ## Figma デザインデータ
 

--- a/src/app/(Main)/page.tsx
+++ b/src/app/(Main)/page.tsx
@@ -21,6 +21,11 @@ import { getNews } from '@/lib/getNews';
 import styles from './Home.module.css';
 export const metadata: Metadata = buildPageMetadata(pages.index, { title: commonTitle });
 
+// News（microCMS）の再検証間隔。getNews() 内の fetch にも同じ値を指定しているが、
+// 環境変数未設定などで fetch 自体が実行されないとページが完全な静的扱いになり、
+// 二度と再生成されなくなる（Issue #55）。ルート単位でも明示して ISR を保証する。
+export const revalidate = 600;
+
 export default async function Home() {
   const news = await getNews();
 

--- a/src/components/News/News.module.css
+++ b/src/components/News/News.module.css
@@ -80,17 +80,6 @@
     }
 }
 
-.News__BlogLink {
-    text-align: right;
-    margin-top: 10px;
-    > a {
-        color: var(--main);
-        &:hover {
-            text-decoration: none;
-        }
-    }
-}
-
 @media screen and (min-width: 1280px) {
     .News {
         width: 340px;

--- a/src/components/News/News.tsx
+++ b/src/components/News/News.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import { NewsPost } from '@/types/news';
 
 import styles from './News.module.css';
@@ -22,9 +20,6 @@ export default function News({ posts }: NewsProps) {
           <p className={styles.News__Empty}>現在お知らせはありません。</p>
         )}
       </section>
-      <div className={styles.News__BlogLink}>
-        <Link href="https://blog.bug-fix.org" target="_blank" rel="noopener noreferrer">SiiD Techブログ</Link>
-      </div>
     </div>
   );
 }

--- a/src/components/News/NewsPost/NewsPost.module.css
+++ b/src/components/News/NewsPost/NewsPost.module.css
@@ -1,7 +1,9 @@
 .NewsPost {
     display: flex;
     flex-direction: row;
-    align-items: baseline;
+    /* タイトルは -webkit-box（line-clamp）のため、baseline 指定だと WebKit で
+       2行目に日付が引っ張られる。flex-start で1行目の高さに揃える */
+    align-items: flex-start;
     gap: 8px;
 }
 

--- a/src/components/News/NewsPost/NewsPost.module.css
+++ b/src/components/News/NewsPost/NewsPost.module.css
@@ -1,23 +1,35 @@
 .NewsPost {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    align-items: baseline;
+    gap: 8px;
 }
 
 .NewsPost__date {
     font-size: 11px;
+    flex: 0 0 auto;
+    font-family: var(--font-poppins);
+}
+
+/* 「yyyy/mm/dd | title」の区切り（装飾のため擬似要素で表現） */
+.NewsPost__date::after {
+    content: '|';
+    margin-left: 8px;
 }
 
 .NewsPost__title {
     font-size: 12px;
     margin: 0;
+    /* カルーセルの高さが記事ごとに大きく変わらないよう2行で省略 */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
 }
 
 @media screen and (min-width: 1280px) {
-    .NewsPost {
-        flex-direction: row;
-        gap: 10px;
-    }
     .NewsPost__date {
         font-size: 12px;
-    } 
+    }
 }

--- a/src/components/News/NewsPost/NewsPost.tsx
+++ b/src/components/News/NewsPost/NewsPost.tsx
@@ -7,11 +7,28 @@ export type NewsPostProps = {
     title: string;
 }
 
+/**
+ * publishedAt（ISO 8601 / UTC）を「yyyy/mm/dd」に整形する。
+ * タイムゾーンを Asia/Tokyo に固定することで、サーバー（UTC）とクライアント（JST）で
+ * 表示がズレる＝Hydration Error になるのを防ぐ。
+ */
+const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
 export default function NewsPost({ dateTime, title }: NewsPostProps) {
+  const date = new Date(dateTime);
+  const formattedDate = Number.isNaN(date.getTime()) ? '' : dateFormatter.format(date);
+
   return (
     <article className={styles.NewsPost}>
-      <time className={styles.NewsPost__date} dateTime={dateTime}>{new Date(dateTime).toLocaleDateString('ja-JP')}</time>
-      <h1 className={styles.NewsPost__title}>{title}</h1>
+      {formattedDate && (
+        <time className={styles.NewsPost__date} dateTime={dateTime}>{formattedDate}</time>
+      )}
+      <p className={styles.NewsPost__title}>{title}</p>
     </article>
   );
 }

--- a/src/lib/getNews.ts
+++ b/src/lib/getNews.ts
@@ -9,7 +9,11 @@ import { NewsPost } from '@/types/news';
  * 必要な環境変数（.env.local / Vercel）:
  * - MICROCMS_SERVICE_DOMAIN … `https://XXXX.microcms.io` の XXXX
  * - MICROCMS_API_KEY         … 読み取り用 API キー
+ *
+ * 本モジュールはサーバー側専用のため、失敗原因は console に出して
+ * Vercel の Runtime Logs から切り分けられるようにしている（Issue #55）。
  */
+/* eslint-disable no-console */
 
 const serviceDomain = process.env.MICROCMS_SERVICE_DOMAIN;
 const apiKey = process.env.MICROCMS_API_KEY;
@@ -21,7 +25,14 @@ const NEWS_LIMIT = 3;
 
 export async function getNews(): Promise<NewsPost[]> {
   if (!serviceDomain || !apiKey) {
-    // 環境変数が未設定の場合はビルドを止めず空配列を返す
+    // 環境変数が未設定の場合はビルドを止めず空配列を返す。
+    // 無言で空になると原因の切り分けができない（Issue #55）ため、
+    // どちらが欠けているかをサーバーログに残す。
+    console.error(
+      '[getNews] microCMS の環境変数が未設定のため News を取得できません。',
+      `MICROCMS_SERVICE_DOMAIN=${serviceDomain ? 'set' : 'missing'}`,
+      `MICROCMS_API_KEY=${apiKey ? 'set' : 'missing'}`,
+    );
     return [];
   }
 
@@ -45,9 +56,18 @@ export async function getNews(): Promise<NewsPost[]> {
         signal: AbortSignal.timeout(5000),
       },
     });
+    if (data.contents.length === 0) {
+      // 200 が返っていても filters が一致しなければ 0 件になる。
+      // 「記事はあるのに表示されない」ケースの切り分け用（Issue #55）。
+      console.warn(
+        `[getNews] microCMS から 0 件が返りました（filters: categories[contains]${COLUMN_CATEGORY_ID}）。`,
+      );
+    }
     return data.contents;
-  } catch {
-    // 取得失敗時も News セクション以外の描画を止めない
+  } catch (error) {
+    // 取得失敗時も News セクション以外の描画を止めないが、
+    // 原因（404: エンドポイント名 / 401: APIキー権限 / タイムアウト等）は必ずログに残す
+    console.error('[getNews] microCMS からの記事取得に失敗しました:', error);
     return [];
   }
 }


### PR DESCRIPTION
Closes #55

## 原因調査（なぜ前回 PR (#30) をマージしても期待値通りにならなかったか）

デプロイ先（`https://siid-web-theta.vercel.app/siid`）を確認したところ、News は「現在お知らせはありません。」のままでした。切り分け結果は以下のとおりです。

| 確認項目 | 結果 |
|---|---|
| コードは本番（main）に載っているか | ✅ 載っている（`src/lib/getNews.ts` / `src/components/News` とも存在） |
| microCMS 側のフィールド定義 | ✅ 実装と一致（`categories[].id === "column"`、`title` / `publishedAt` / `id`）。ブログの配信データで確認済み |
| 記事URLの形式 | ✅ `https://blog.bug-fix.org/blog/{id}` で一致（例: `/blog/release-claude-code-engineering-course`） |
| ISR が回っているか | ❌ **回っていない**。レスポンスが `x-nextjs-prerender: 1` かつ `age: 2640`（44分）。`revalidate: 600` の fetch が実行されていれば10分で再検証されるはず |

`getNews()` は環境変数が無いと **fetch を実行せずに即 return** します。この場合 ISR の再検証自体が登録されないため、**空の状態で静的生成されたページが恒久的にキャッシュされ続けます**（= 環境変数を後から Vercel に足しても、再デプロイしない限り永久に反映されない）。上記の `age` はこの症状と一致します。

さらに根本的な問題として、**環境変数欠落・エンドポイント名の誤り・APIキーの権限不足・0件ヒットのすべてが無言で空配列になり、同じ画面表示になる**ため原因が特定できない状態でした。本 PR ではここに診断ログを追加しています。

> [!IMPORTANT]
> **マージ後、Vercel 側で以下の確認が必要です。**
> 1. `MICROCMS_SERVICE_DOMAIN` / `MICROCMS_API_KEY` が **Production 環境（Preview だけでなく）** に登録されているか
> 2. 登録済みなら **Production を再デプロイ**（環境変数の変更は自動再デプロイされないため）
> 3. それでも表示されない場合は **Vercel の Runtime Logs** に `[getNews]` で始まるログが出るので、その内容を共有してください（原因が一意に特定できます）

## 変更内容

- **表示形式を `yyyy/mm/dd | title` に変更**（`NewsPost.tsx` / `NewsPost.module.css`）
  - 従来は `toLocaleDateString('ja-JP')` でゼロ埋めされず `2026/8/5` になっていた
  - `Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo' })` でタイムゾーンを固定。`publishedAt` は UTC のため、固定しないとサーバー(UTC)/クライアント(JST)で日付がズレて Hydration Error になる（例: `2026-04-15T16:00:00Z` → JST では `2026/04/16`）
  - `|` は `.NewsPost__date::after` の擬似要素。タイトルは 2 行で省略
  - 記事タイトルの `h1` を `p` に変更（1ページ内に `h1` が複数出ていたため）
- **「SiiD Techブログ」リンクを削除**（`News.tsx` / `News.module.css`）— Issue の要件だが前回 PR で未対応だった
- **`getNews()` に診断ログを追加**（`src/lib/getNews.ts`）— 環境変数欠落 / 0件 / API エラーを区別してサーバーログに出力
- **仕様書を更新**（`docs/spec/01_project-overview.md`）— 表示形式・タイムゾーン固定の理由・ログによる切り分け表・「環境変数変更後は再デプロイが必要」を追記

なお、カルーセル（矢印・スワイプで1件ずつ切替）はご指示どおり維持しています。

## 確認方法

- `npm run lint` / `npm run typecheck` — いずれも通過
- ローカル（`next dev`）で microCMS の実データ相当のモックを流し込み、PC（1440px）/ SP（375px）両方で描画を確認
  - 日付が `2026/08/05` とゼロ埋めされ、`|` 区切りでタイトルが続くこと
  - UTC 16:00 の記事が JST の翌日として表示されること（`2026-04-15T16:00:00Z` → `2026/04/16`）
  - リンク先が `https://blog.bug-fix.org/blog/{id}` になっていること
  - 「SiiD Techブログ」リンクが消えていること

> [!NOTE]
> スクリーンショットは実データが必要なため、環境変数設定後のプレビューデプロイで確認をお願いします。ローカルではモックデータで PC / SP とも `2026/08/05 | AI時代に生存できる…` の形式で表示されることを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
