### PR TITLE
docs: エージェント向けコンテキストを実装の現状に同期し project-status スキルを追加

### DIFF
--- a/.claude/skills/project-status/SKILL.md
+++ b/.claude/skills/project-status/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: project-status
+description: SiiD Web の現況・残タスク・クローズ可能な Issue を 1 バッチで棚卸しする。ユーザーが「残タスクを列挙して」「今どこまで進んでる？」「完了してそうな Issue をクローズ提案して」「Issue と PR を確認して」と言ったときに使う。
+---
+
+# project-status: 現況の棚卸し
+
+「残タスクは？」「クローズしていい Issue は？」といった問いに、**探索を往復せず一発で**答えるための手順。
+毎回 `dig` / `curl` / `find` でインフラや構成を再発見しないこと（下の「既知の前提」を先に読む）。
+
+## 手順
+
+### 1. まず 1 コマンドで全部取る
+
+以下をそのまま 1 回の Bash 呼び出しで実行する。個別に分けて何度も叩かない。
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git fetch origin -q
+echo "=== main <-> develop 乖離（left=main only / right=develop only） ==="
+git rev-list --left-right --count origin/main...origin/develop
+git log --oneline origin/main..origin/develop
+echo "=== ローカル現在地 ==="
+git branch --show-current; git status --short
+echo "=== Open Issues ==="
+gh issue list --state open --limit 100
+echo "=== 直近の PR（open/merged 両方） ==="
+gh pr list --state all --limit 30 --json number,title,state,baseRefName,headRefName,mergedAt \
+  --template '{{range .}}#{{.number}} [{{.state}}] {{.headRefName}} -> {{.baseRefName}} {{.title}}{{"\n"}}{{end}}'
+echo "=== 仕様書の未確定事項 ==="
+grep -n -A20 "^## 未確定事項" docs/spec/*.md
+```
+
+### 2. 「実装済みか」はコードで判定する
+
+仕様書の「実装状況」表や CLAUDE.md は遅れていることがある。Issue が実際に片付いているかは**コードで確かめる**：
+
+```bash
+git ls-tree -r --name-only origin/develop src/app   # 実在するページ
+git log --oneline origin/develop -- <関係するパス>   # その機能に触れたコミット
+```
+
+Issue 本文の完了条件チェックリストと、上の実体を突き合わせる。
+
+### 3. クローズ提案の判断基準
+
+- **クローズ提案してよい**: 完了条件を満たすコードが `origin/develop` に入っている／別 PR で実質対応済み／`Closes #N` の書き漏れで自動クローズされなかっただけ
+- **クローズしない**: ユーザー側の外部作業（DNS 設定・Vercel 設定・デザイナー確認）が完了条件に含まれ、その完了が確認できていない
+- 判断がつかないものは「要確認」として分けて出す。**Claude が勝手にクローズしない。必ず提案に留め、実行はユーザーの承認後**
+
+### 4. 出力フォーマット
+
+依頼が「簡潔に列挙して」の場合は 1 タスク 1 行。長い解説を付けない。
+
+```
+## クローズ提案（根拠つき）
+- #N タイトル — 〜が origin/develop にあるため完了と判断
+
+## 残タスク（Issue）
+- #N 一言
+
+## 残タスク（仕様書側・Issue 化されていないもの）
+- 一言（出典: docs/spec/0X_xxx.md）
+
+## 要確認
+- #N なぜ判断できないか
+```
+
+## 既知の前提（再調査しない）
+
+これらは調査済みの事実。変わったと疑う理由がない限り、コマンドで再確認しない。
+
+- ローカルのワークツリーは `main` にチェックアウトされたままのことが多く、`develop` より遅れている。基準は常に `origin/develop`
+- 公開まわり（Cloudflare / DNS / Vercel / 旧サイトからの移行）の設計は `docs/spec/06_migration.md` と `docs/spec/05_deploy.md` に書かれている。`dig` や `curl` で調べ直す前にこの 2 つを読む
+- Vercel の Production Branch は `main`。`develop` → `main` のリリース PR が本番反映のトリガー
+- デザイナー確認待ち・ユーザーの外部作業待ちの項目は `docs/spec/03_pages.md` / `05_deploy.md` の末尾にある
+
+## 更新ルール
+
+棚卸しの過程で仕様書と実装の食い違いを見つけたら、その場でユーザーに報告し、修正はドキュメント更新の PR にまとめる（CLAUDE.md の「ドキュメントとコードが食い違ったときの優先順位」に従う）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,43 @@ ITエンジニア転職 × 生成AI特化プログラミングスクール「Sii
 
 - `docs/spec/01_project-overview.md` — 技術選定（GSAP / Vercel / 外部フォーム）・ページ実装状況・**Figma ノード ID 対応表とレート制限の注意**
 - `docs/spec/02_opening-animation.md` — オープニング演出（ローディング→FV）の詳細仕様
-- `docs/spec/03_pages.md` — 未実装ページ（courses / after-support / contact / 404）の仕様
+- `docs/spec/03_pages.md` — 各下層ページ（courses / service / counseling / line ほか）の実装仕様
 - `docs/spec/04_workflow.md` — Issue 駆動開発のルール（下記サマリ）
 - `docs/spec/05_deploy.md` — Vercel デプロイ計画・公開前チェックリスト
+- `docs/spec/06_migration.md` — 旧 `bug-fix.org/siid` からの移行・Cloudflare 前段方式のリリース計画
 
 **ワークフローのサマリ**: GitHub Issue 起票 → develop から `feature/{issue番号}-{slug}` ブランチ → 実装 → lint+typecheck → develop 向け PR（`Closes #N`）→ `/code-review` でセルフレビュー・修正 → **マージはユーザーが行う**。main / develop への直接コミット禁止。実装タスクは `/feature-work` スキルに従う。
 
 **ブランチ**: `main` = 本番（Vercel の Production Branch。develop からのリリース PR のみ受ける）/ `develop` = デフォルトブランチ・日常の PR マージ先。feature ブランチから直接 main へ PR を出さない。
 
 仕様変更・ヒアリングでの決定事項は、実装 PR と同じ PR 内で該当仕様書に反映すること。
+
+### 作業開始時の前提確認（毎セッション）
+
+ローカルのワークツリーは `main`（本番ブランチ）にチェックアウトされたままのことがあり、その場合 `develop` より数コミット遅れている。**調査・実装のどちらを始めるときも、まず develop を基準に揃える。**
+
+```bash
+git fetch origin -q
+git rev-list --left-right --count origin/main...origin/develop  # ← 乖離コミット数を先に把握
+git switch develop && git pull -q origin develop
+```
+
+`git pull` だけを実行して「最新化した」と判断しないこと（`main` にいれば develop の変更は入らない）。
+
+### ドキュメントとコードが食い違ったときの優先順位
+
+**コードが正**。この CLAUDE.md や `docs/spec/` の記述と実装が矛盾していたら、コードを信じて作業を進め、**気付いた食い違いはその PR 内でドキュメント側を直す**（推測で実装を変えない）。特に次の情報は「コードが唯一の情報源」で、ドキュメントは要約に過ぎない：
+
+| 情報 | 唯一の情報源 |
+|------|------------|
+| ページ URL / メタデータ | `src/constants/meta.ts` |
+| ナビ・フッターのメニュー構成 | `src/constants/menuItems.ts` |
+| SNS リンク | `src/constants/snsItems.ts` |
+| ルーティング（実在するページ） | `src/app/` のディレクトリ構成 |
+
+### 現況・残タスクの調べ方
+
+「今どこまで進んでいる？」「残タスクは？」「クローズしてよい Issue は？」といった棚卸し系の依頼は `/project-status` スキル（`.claude/skills/project-status/`）の手順に従う。毎回ゼロから探索せず、1 バッチのコマンドで状況を取る。
 
 ---
 
@@ -46,6 +74,8 @@ npm run lint && npm run typecheck
 | Framework | Next.js 15（App Router） |
 | Language | TypeScript 5 |
 | Styling | CSS Modules + CSS Custom Properties |
+| Animation | GSAP 3.15（オープニング演出・スクロール演出） |
+| CMS | microCMS（`microcms-js-sdk`。TOP の News セクションが SiiD BLOG の「コラム」記事を取得） |
 | Game | Phaser 3.90（404ページのミニゲーム専用。`next/dynamic` + `ssr: false` で404ページ限定ロード） |
 | Slider | Swiper 12 |
 | CSS Reset | sanitize.css |
@@ -57,49 +87,59 @@ npm run lint && npm run typecheck
 
 ## ディレクトリ構造
 
+**`src/app/` は `(Main)` と `(Lp)` の 2 つのルートグループに分かれており、それぞれが独立した root layout（`html`/`body`）を持つ。** 共通クロームを持つ通常ページは `(Main)`、旧サイトから移植した独立 LP は `(Lp)`。
+
 ```
 src/
-├── app/                         # Next.js App Router
-│   ├── (LowerPages)/            # 下層ページ（ルートグループ）
-│   │   ├── layout.tsx           # 下層ページ共通レイアウト（Header なし、NavigationPcLower あり）
-│   │   ├── career-path/         # 卒業生の進路ページ
-│   │   │   ├── page.tsx         # /career-path → /career-path/1 へリダイレクト
-│   │   │   └── [page]/page.tsx  # ページネーション付きリスト
-│   │   ├── community/page.tsx   # SiiDコミュニティページ
-│   │   ├── courses/page.tsx     # コース一覧ページ（※コンテンツ未実装）
-│   │   └── service/page.tsx     # サービスページ
-│   ├── layout.tsx               # ルートレイアウト（html/body・Icons・NavigationSp・Footer）
-│   ├── page.tsx                 # ホームページ（TOPページ）
-│   ├── not-found.tsx            # 404ページ（dino風ミニゲーム付き）
-│   ├── sitemap.ts               # sitemap.xml（実在ページ + career-path 全ページ番号。robots.txt はルートドメイン側の別プロジェクトで対応）
-│   ├── apple-icon.png           # apple-touch-icon（Next.js ファイル規約で自動配線）
-│   ├── favicon.ico
-│   └── Home.module.css
-├── components/                  # 再利用可能 UI コンポーネント
+├── app/                                  # Next.js App Router
+│   ├── (Main)/                           # 通常ページ群（共通クロームあり）
+│   │   ├── layout.tsx                    # root layout（html/body・GtmNoScript・Analytics・Icons・NavigationSp・Footer）
+│   │   ├── page.tsx                      # TOPページ（Opening / Hero / News ほか。revalidate = 600）
+│   │   ├── not-found.tsx                 # 404ページ（dino風ミニゲーム付き）
+│   │   ├── [...notFound]/page.tsx        # どのグループにも一致しない URL を (Main) の 404 へ落とす catch-all
+│   │   ├── Home.module.css
+│   │   └── (LowerPages)/                 # 下層ページ（Header なし、NavigationPcLower あり）
+│   │       ├── layout.tsx
+│   │       ├── career-path/              # 卒業生の進路（page.tsx → /career-path/1 へリダイレクト、[page]/ が本体）
+│   │       ├── community/                # SiiDコミュニティ
+│   │       ├── counseling/               # 無料カウンセリング（complete/ = 予約完了・CV計測）
+│   │       ├── counseling-complete/      # 旧 URL 互換の申込完了ページ
+│   │       ├── counseling-complete-lp-1/ # lp-1 用の申込完了ページ（noindex・OpenAI Ads CV）
+│   │       ├── courses/                  # コース一覧（比較表・プラン）
+│   │       ├── line/                     # LINE 登録
+│   │       ├── service/                  # サービス一覧（after-support の実体もここ）
+│   │       └── white-paper/              # 資料請求
+│   ├── (Lp)/                             # 広告流入用の独立LP（共通クローム・globals.css を持ち込まない）
+│   │   ├── layout.tsx                    # LP 専用 root layout
+│   │   ├── fonts.ts / lp1.css
+│   │   └── lp-1/page.tsx
+│   ├── sitemap.ts                        # sitemap.xml（robots.txt はルートドメイン側の別プロジェクトで対応）
+│   ├── apple-icon.png                    # apple-touch-icon（Next.js ファイル規約で自動配線）
+│   └── favicon.ico
+├── components/                           # 再利用可能 UI コンポーネント（Opening / Hero / News / Courses / Counseling ほか）
 ├── constants/
-│   ├── common.ts                # BREAK_POINT(1280)、Google Fonts 設定
-│   ├── meta.ts                  # ページメタデータ・URL 定数（commonTitle、pages、SITE_URL、buildPageMetadata()）
-│   ├── menuItems.ts             # ナビメニュー項目
-│   └── snsItems.ts              # SNSリンク（snsItems / snsFooterItems）
-├── data/                        # 静的 JSON データ
-│   ├── books.json
-│   ├── graduates/               # 卒業生データ（student-1.json 〜 student-7.json）
-│   └── subSupporters.json
+│   ├── common.ts                         # BREAK_POINT(1280)、Google Fonts 設定
+│   ├── meta.ts                           # ページメタデータ・URL 定数（commonTitle、pages、SITE_URL、buildPageMetadata()）
+│   ├── menuItems.ts                      # ナビメニュー項目
+│   ├── snsItems.ts                       # SNSリンク（snsItems / snsFooterItems）
+│   ├── conversionFocusedPages.ts         # CV 重視ページの判定
+│   ├── courseData.ts / coursePlans.ts    # コース一覧の表示データ
+├── data/                                 # 静的 JSON データ
+│   ├── books.json / coursePlans.json / linePresents.json / subSupporters.json
+│   └── graduates/                        # 卒業生データ（student-1.json 〜 student-34.json）
 ├── hooks/
-│   ├── useIsPc.ts               # PC/SP 判定（BREAK_POINT=1280px 基準）
-│   └── useScroll.ts             # スクロール量取得
-├── lib/                         # データ取得ロジック
-│   ├── getBooks.ts
-│   ├── getCareerPathData.ts
-│   └── getSubSupporters.ts
+│   ├── useIsPc.ts                        # PC/SP 判定（BREAK_POINT=1280px 基準）
+│   └── useScroll.ts                      # スクロール量取得
+├── lib/                                  # データ取得ロジック
+│   ├── getBooks.ts / getCareerPathData.ts / getCoursePlans.ts
+│   ├── getLinePresents.ts / getSubSupporters.ts
+│   └── getNews.ts                        # microCMS から News を取得（サーバー側実行）
 ├── styles/
-│   └── globals.css              # グローバルスタイル・CSS変数・カスタムフォント定義
-├── types/
-│   ├── career.ts
-│   └── pagination.ts
+│   └── globals.css                       # グローバルスタイル・CSS変数・カスタムフォント定義
+├── types/                                # career.ts / news.ts / pagination.ts / global.d.ts
 └── utils/
-    ├── helper.ts                # handleStringHTML()：description の <br> タグ処理
-    ├── pagination.ts            # getTotalPages() などページネーション計算
+    ├── helper.ts                         # handleStringHTML()：description の <br> タグ処理
+    ├── pagination.ts                     # getTotalPages() などページネーション計算
     └── youtube.ts
 ```
 
@@ -107,11 +147,15 @@ src/
 
 ## レイアウト構造
 
-- **`src/app/layout.tsx`** — ルートレイアウト（唯一 `html`/`body` を持つ）。`Icons`（SVGスプライト）・`NavigationSp`（SP用ハンバーガーメニュー）・`Footer`・フォント変数を全ページ共通で提供
-- **`src/app/(LowerPages)/layout.tsx`** — 下層ページ用。`NavigationPcLower` のみ追加
-- TOPページの `Header` は `src/app/page.tsx` 内で使用
+**root layout は 2 つある**（ルートグループごとに独立。`src/app/layout.tsx` は存在しない）。
 
-※ 2026-07（Issue #24）まで root layout が無い変則構成（`homeLayout.tsx` が html/body を持つ）だったが、`npm run build` が失敗するため現構成に統合済み。
+- **`src/app/(Main)/layout.tsx`** — 通常ページ用の root layout。`html`/`body`・`GtmNoScript`・`Analytics`・`Icons`（SVGスプライト）・`NavigationSp`（SP用ハンバーガーメニュー）・`Footer`・フォント変数、`globals.css` / sanitize.css を提供
+- **`src/app/(Main)/(LowerPages)/layout.tsx`** — 下層ページ用。`NavigationPcLower` のみ追加
+- **`src/app/(Lp)/layout.tsx`** — 独立LP用の root layout。共通クロームと `globals.css` を持ち込まず、旧LPのデザインを `(Main)` と完全に隔離して再現（Issue #40）。フォントは `(Lp)/fonts.ts`
+- TOPページの `Header` は `src/app/(Main)/page.tsx` 内で使用
+
+※ グループ分割により「どのグループにも属さない URL」が 404 に落ちなくなるため、`src/app/(Main)/[...notFound]/page.tsx` の catch-all で `notFound()` を呼んで `(Main)` の 404 に着地させている。新しいルートグループを追加する場合はこの経路を壊していないか確認すること。
+※ 2026-07（Issue #24）まで root layout が無い変則構成（`homeLayout.tsx` が html/body を持つ）だったが、`npm run build` が失敗するため統合済み。
 
 ---
 
@@ -212,16 +256,26 @@ handleStringHTML(pages.xxx.description, true)
 
 ## ページルーティング
 
+パスは `src/app/` からの相対。`(Main)` 配下は共通クロームあり、`(Lp)` 配下は独立LP。
+
 | URL | ファイル | 備考 |
 |-----|---------|------|
-| `/` | `src/app/page.tsx` | TOPページ |
-| `/career-path` | `src/app/(LowerPages)/career-path/page.tsx` | `/career-path/1` へリダイレクト |
-| `/career-path/[page]` | `src/app/(LowerPages)/career-path/[page]/page.tsx` | ページネーション、`?id=` でモーダル表示 |
-| `/courses` | `src/app/(LowerPages)/courses/page.tsx` | コンテンツ未実装（プレースホルダーあり） |
-| `/community` | `src/app/(LowerPages)/community/page.tsx` | |
-| `/service` | `src/app/(LowerPages)/service/page.tsx` | |
-| `/contact` | **未実装** | `ContactButton` リンク先 |
-| `/after-support` | **未実装** | `menuItems.ts` に記載あり |
+| `/` | `(Main)/page.tsx` | TOPページ。`revalidate = 600`（News の ISR） |
+| `/career-path` | `(Main)/(LowerPages)/career-path/page.tsx` | `/career-path/1` へリダイレクト |
+| `/career-path/[page]` | `(Main)/(LowerPages)/career-path/[page]/page.tsx` | ページネーション、`?id=` でモーダル表示 |
+| `/courses` | `(Main)/(LowerPages)/courses/page.tsx` | 比較表・プラン。プラン別アンカーは `COURSE_PLAN_ANCHOR_IDS` |
+| `/community` | `(Main)/(LowerPages)/community/page.tsx` | |
+| `/service` | `(Main)/(LowerPages)/service/page.tsx` | `after-support` の実体（`Support` セクション）もここ |
+| `/counseling` | `(Main)/(LowerPages)/counseling/page.tsx` | `ContactButton` のリンク先（`/contact` は存在しない） |
+| `/counseling/complete` | `(Main)/(LowerPages)/counseling/complete/page.tsx` | 予約完了・CV 計測（noindex） |
+| `/counseling-complete` | `(Main)/(LowerPages)/counseling-complete/page.tsx` | 旧 URL 互換（noindex） |
+| `/counseling-complete-lp-1` | `(Main)/(LowerPages)/counseling-complete-lp-1/page.tsx` | lp-1 用の申込完了（noindex・OpenAI Ads CV） |
+| `/line` | `(Main)/(LowerPages)/line/page.tsx` | LINE 登録 |
+| `/white-paper` | `(Main)/(LowerPages)/white-paper/page.tsx` | 資料請求（公式LINE誘導） |
+| `/lp-1` | `(Lp)/lp-1/page.tsx` | 広告流入用LP。共通クローム無し・noindex |
+| 404 | `(Main)/not-found.tsx` + `(Main)/[...notFound]/page.tsx` | dino風ミニゲーム付き |
+
+※ `/contact` と `/after-support` は**ルートとして存在しない**（それぞれ `/counseling` と `/service` が実体）。ナビ構成の実際の値は `src/constants/menuItems.ts` を見ること。
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,15 @@ AI ベース開発のための仕様書・運用ドキュメント一式。**実
 |------|------|
 | [01_project-overview.md](./spec/01_project-overview.md) | プロジェクト概要・技術選定・ページ一覧・Figma 対応表 |
 | [02_opening-animation.md](./spec/02_opening-animation.md) | オープニング演出(ローディング → ファーストビュー)仕様 |
-| [03_pages.md](./spec/03_pages.md) | 未実装ページの実装仕様 |
+| [03_pages.md](./spec/03_pages.md) | 各下層ページ(courses / service / counseling / line ほか)の実装仕様 |
 | [04_workflow.md](./spec/04_workflow.md) | Issue / ブランチ / PR の開発ワークフロー |
 | [05_deploy.md](./spec/05_deploy.md) | Vercel デプロイ・公開計画 |
 | [06_migration.md](./spec/06_migration.md) | 現行 bug-fix.org/siid からの移行・リリース計画(Cloudflare 前段方式) |
 
 ## 更新ルール
 
+- **実装と食い違ったらコードが正**。ドキュメントは要約であり、ページ URL は `src/constants/meta.ts`、ルーティングは `src/app/` の構成、ナビは `src/constants/menuItems.ts`、SNS リンクは `src/constants/snsItems.ts` が唯一の情報源
+- 食い違いに気付いたら、その場で作業中の PR 内でドキュメント側を直す(次回以降のセッションが誤った前提で調査を始めるのを防ぐため)
 - 仕様変更が発生したら、実装 PR と同じ PR 内で該当ドキュメントも更新する
 - ヒアリングで決定した事項は口頭(チャット)で終わらせず、必ず該当ドキュメントに反映する
 - 未確定事項は各ドキュメント末尾の「未確定事項」セクションに列挙し、確定したら本文へ昇格させる

--- a/docs/spec/01_project-overview.md
+++ b/docs/spec/01_project-overview.md
@@ -25,19 +25,24 @@ ITエンジニア転職 × 生成AI特化プログラミングスクール「Sii
 
 | URL | 状態 | Figma フレーム(主なもの) |
 |-----|------|------------------|
-| `/` | 実装済み(FVアニメ未実装) | `TOP_nomal` (3506:8246), `TOP` (3595:9208 / 3600:11840) |
+| `/` | 実装済み(オープニング演出 `Opening` 実装済み。News は microCMS 連携・`revalidate = 600`) | `TOP_nomal` (3506:8246), `TOP` (3595:9208 / 3600:11840) |
 | `/career-path` → `/career-path/[page]` | 実装済み | `C-1 卒業生の進路` (3506:10507), モーダル (3506:10655), SP (3506:5977) |
-| `/courses` | **プレースホルダーのみ** | `B-1 コース一覧` (3506:9919), SP (3506:6335) |
+| `/courses` | 実装済み(比較表・プラン。プラン別アンカーは `COURSE_PLAN_ANCHOR_IDS`) | `B-1 コース一覧` (3506:9919), SP (3506:6335) |
 | `/community` | 実装済み | `E-1 コミュニティの雰囲気` (3506:11116), SP (3506:7723) |
 | `/service` | 実装済み | `D-1 サービス一覧` (3506:10951), SP (3506:7084) |
 | `/after-support` | **独立ページ無し**(Issue #11)。実体は `/service` 内 `Support` セクション。ナビは『サービス一覧』→ /service に変更 | `D-1 サービス一覧` 内(3506:10951) |
 | `/line` | 実装済み(2026-07) | `G-1 LINE登録` PC (3506:11427) / SP (3506:6128) |
-| `/contact` | **未実装**(ContactButton のリンク先は現状 `/counseling`) | ※ `G-1 LINE登録` は独立ページ `/line` として実装済み。`/contact` の実体は要確認のまま |
-| 404 | 実装済み(2026-07 / Issue #24)。dino風ミニゲーム付き | `H-1 409` (3506:11730)。H-1 410〜413 は存在しないことを確認済み(SP はPC縮小構成) |
-| `/counseling` | 未実装(meta.ts に定義のみ) | 要確認 |
-| `/lp-1` | 実装済み(2026-07 / Issue #40)。旧サイト `bug-fix.org/siid/lp-1` から移植した広告流入用の独立LP。共通クローム無し・noindex | Figma 対応なし(旧LPの忠実再現) |
+| `/counseling` | 実装済み。`ContactButton` のリンク先 | 要確認 |
+| `/counseling/complete` | 実装済み(予約完了・CV 計測、noindex) | Figma 対応なし |
+| `/counseling-complete` | 実装済み(旧 URL 互換、noindex) | Figma 対応なし |
+| `/contact` | **ルートとして存在しない**。実体は `/counseling` | — |
+| 404 | 実装済み(2026-07 / Issue #24)。dino風ミニゲーム付き。`(Main)/[...notFound]` の catch-all で未知 URL を着地させる | `H-1 409` (3506:11730)。H-1 410〜413 は存在しないことを確認済み(SP はPC縮小構成) |
+| `/lp-1` | 実装済み(2026-07 / Issue #40)。旧サイト `bug-fix.org/siid/lp-1` から移植した広告流入用の独立LP。共通クローム無し・noindex。root layout は `(Lp)/layout.tsx` | Figma 対応なし(旧LPの忠実再現) |
 | `/counseling-complete-lp-1` | 実装済み(2026-07 / Issue #40)。旧サイトから移植した申込完了ページ(noindex)。OpenAI Ads CV計測 `appointment_scheduled` を発火 | Figma 対応なし |
 | `/white-paper` | 実装済み(2026-07 / Issue #40)。旧サイトから移植した資料請求ページ(公式LINE誘導) | Figma 対応なし |
+
+> ルーティングの実体は `src/app/` のディレクトリ構成、URL とメタデータの実体は `src/constants/meta.ts` が唯一の情報源。
+> この表と食い違ったらコードが正で、気付いた時点でこの表を直す。
 
 ## TOPページ News セクション（microCMS 連携・Issue #30 / #55）
 
@@ -98,4 +103,4 @@ Figma 内「アニメーションについて」(3235:2345) にはデザイナ�
 
 ## 未確定事項
 
-- `/counseling` ページを作るか、`/contact` に統合するか
+- 問い合わせフォームの外部サービス選定([03_pages.md](./03_pages.md) 参照)


### PR DESCRIPTION
Closes #57

## 変更概要

前日（2026-08-28）のセッションログを全ワークツリー分振り返り、「同じ調査を毎回やり直している」原因を潰した。

### 1. CLAUDE.md を `origin/develop` の実装に同期

CLAUDE.md は `(Main)` / `(Lp)` ルートグループ分割前のままで、実在するページを「未実装」と書いていた。誤った地図から探索が始まるため毎回の手数が増えていた。

- ディレクトリ構造を `(Main)` / `(Lp)` の 2 root layout 構成に更新（`src/app/layout.tsx` は存在しない）
- ルーティング表に `/counseling` `/counseling/complete` `/counseling-complete` `/counseling-complete-lp-1` `/line` `/white-paper` `/lp-1` `[...notFound]` を追加。`/contact` `/after-support` は「ルートとして存在しない」と明記
- レイアウト構造に `(Lp)/layout.tsx` と catch-all 404 の経路を追記
- 技術スタックに GSAP / microCMS を追加

### 2. 迷子と再調査を防ぐルールを追加

- **作業開始時の前提確認**: ローカルは `main`（本番ブランチ）にチェックアウトされたままのことがあり、`git pull` だけでは develop の変更が入らない。`git fetch` → 乖離確認 → `git switch develop` の手順を明記
- **ドキュメントとコードが食い違ったらコードが正**。ページ URL / ナビ / SNS リンク / ルーティングの「唯一の情報源」をファイル名で表にした。気付いた食い違いはその PR 内で直す

### 3. `/project-status` スキルを追加（`.claude/skills/project-status/`）

「残タスクを列挙して」「クローズしていい Issue は？」への回答手順。Issue / PR / ブランチ乖離 / 未確定事項を **1 バッチのコマンド**で取得し、実装済み判定はコードで行う。DNS・Vercel 等を `dig` / `curl` で調べ直さないよう「既知の前提」として仕様書への参照を書いた。クローズは提案に留め、実行はユーザー承認後というガードも明記。

### 4. 仕様書の同期

- `docs/spec/01_project-overview.md` のページ実装状況表を実態に同期（`/courses` の「プレースホルダーのみ」と本文の「実装済み」の矛盾を解消、`/counseling` 系を追加）。「未確定事項」から解決済みの項目を削除
- `docs/README.md` の更新ルールに「実装と食い違ったらコードが正」を追加

## 確認方法

コード変更なし（ドキュメントと Claude スキルのみ）。

```bash
npm run lint && npm run typecheck   # 両方 pass 済み
```

記述の裏取り:

```bash
git ls-tree -r --name-only origin/develop src/app   # ルーティング表と一致
```