### PR TITLE
docs: 日次振り返りの手順を daily-retro スキルとして固定 (#59)

### DIFF
--- a/.claude/skills/daily-retro/SKILL.md
+++ b/.claude/skills/daily-retro/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: daily-retro
+description: 前日の会話ログ（全ワークツリー）を振り返り、「より少ない手順で期待値通りの成果を出すには」の観点で改善点を洗い出し、スキル／ドキュメントに反映して PR を作る。ユーザーが「前日の振り返り」「日次レトロ」「昨日のログを振り返って」「daily-retro」と言ったときに使う。
+---
+
+# daily-retro: 前日ログの振り返り
+
+毎朝の定型依頼。**ログの場所探しに時間を使わず、振り返りと成果物に時間を使う**ための手順。
+
+過去の失敗（2026-09-02 実行分）: ログの所在・前日レンジの絞り込みをゼロから探索し、
+**7 回のツール呼び出しを全部“探索”に使い切ったところでセッションが中断、成果物ゼロで消滅**した。
+以下の「既知の前提」は調査済みの事実なので、疑う理由がない限り再発見しない。
+
+## 手順
+
+### 1. ログ収集は 1 コマンドで終わらせる
+
+```bash
+python3 .claude/skills/daily-retro/scripts/collect_logs.py          # 前日(JST)
+python3 .claude/skills/daily-retro/scripts/collect_logs.py 2026-09-02   # 日付指定
+python3 .claude/skills/daily-retro/scripts/collect_logs.py --full   # 発話本文を長めに
+```
+
+全ワークツリー分のセッションを横断し、セッションごとに
+「時間帯 / ユーザー発話 / ツール呼び出しの並び / 最後の assistant 発話 / 中断フラグ」を出す。
+別リポジトリを対象にするときは `RETRO_MATCH=<repo名>` を付ける。
+
+### 2. リポジトリ側の実績も 1 コマンドで取る
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && git fetch origin -q
+git log --all --since="2 days ago" --date=iso --pretty='%h %ad %d %s'
+gh pr list --state all --limit 10 --json number,title,state,baseRefName,headRefName \
+  --template '{{range .}}#{{.number}} [{{.state}}] {{.headRefName}} -> {{.baseRefName}} {{.title}}{{"\n"}}{{end}}'
+gh issue list --state open --limit 20
+```
+
+### 3. 何を「反省点」とみなすか
+
+ログを読むときの着眼点。**該当しなければ無理にひねり出さない**（無意味なドキュメント改変はノイズ）。
+
+- **往復した探索**: 同じ事実を 2 回以上調べ直している → 「既知の前提」としてスキル/CLAUDE.md に固定する
+- **手戻り**: ユーザーの指摘で方針を変えた／レビューで同種の指摘を繰り返し受けた → ルール化する
+- **前提のズレ**: ドキュメントの記述が古く、実装と食い違っていた → ドキュメントを直す
+- **中断・成果物ゼロ**: セッションが途中で落ちて何も残っていない → 進め方（早めのコミット）を見直す
+- **依頼文とプロジェクトルールの矛盾**: 例「main へ PR」だが CLAUDE.md は develop 向け → 判断をスキルに明記する
+
+### 4. 成果物を出す（中断に強い順序で）
+
+**探索より先に成果物の受け皿を作る。** 前回はこれをやらずに全部失った。
+
+1. `gh issue create` で Issue 起票（振り返りの根拠と完了条件を本文に書く）
+2. `git switch -C docs/{issue番号}-{slug} origin/develop` — **必ず `origin/develop` を基点に切る**
+   （ローカルは `main` や未マージのブランチに載っていることがある）
+3. スキル追記／ドキュメント更新を書いたら**すぐコミット**する。全部書き終えてからまとめてコミットしない
+4. `npm run lint && npm run typecheck`（ドキュメントのみの変更でもコミット前に一度通す）
+5. PR 作成（`Closes #N`）
+
+### 5. PR のベースブランチ
+
+依頼文が「main へ PR」でも、**CLAUDE.md のルールに従って `develop` 向けに出す**
+（`main` は develop からのリリース PR のみ受ける）。PR 本文にその旨を 1 行書いて認識を揃える。
+マージはユーザーが行う。
+
+### 6. 報告フォーマット
+
+```
+## 前日の実績
+- （セッション/PR/コミットを 1 行ずつ）
+
+## 反省点
+- 事象 → なぜ手順が増えたか → どう固定したか
+
+## 実施した変更
+- ファイル: 何を追加/更新したか
+
+## PR
+- #N URL（base: develop）
+```
+
+## 既知の前提（再調査しない）
+
+- セッションログ: `~/.claude/projects/<cwd のスラッシュをハイフンに変換した名前>/<session-uuid>.jsonl`
+  - **ワークツリーごとに別ディレクトリ**になる。siid-web では
+    `-Users-horiguchimasato-Documents-develop-siid-web`（本体）、
+    `...-siid-web--claude-worktrees-*`、`-Users-horiguchimasato-orca-workspaces-siid-web-*` が該当。
+    `*siid-web*` のパス一致で全部拾える
+  - サブエージェントのログは `<session-uuid>/subagents/*.jsonl`
+- **timestamp は UTC。ローカルは JST（+9）。** 「前日(JST)」= `[D-1T15:00:00Z, DT15:00:00Z)`。
+  `grep '"timestamp":"YYYY-MM-DD'` で日付前方一致させると 9 時間ぶんズレる（前回やらかした）
+- ログ 1 ファイルは数百 KB〜数 MB。`cat` せず、必ず `type` と `message.content` を絞って抽出する
+  （`type` は `user` / `assistant` / `attachment` / `system` など。本文は `content[].text`、
+  ツールは `content[].type == "tool_use"`）
+- 振り返り対象日にセッションが 1 本もない日もある。その場合は「対象なし」と報告して終える

--- a/.claude/skills/daily-retro/scripts/collect_logs.py
+++ b/.claude/skills/daily-retro/scripts/collect_logs.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""前日（JST）のセッションログを全ワークツリー分まとめて要約出力する。
+
+使い方:
+    python3 .claude/skills/daily-retro/scripts/collect_logs.py            # 前日(JST)
+    python3 .claude/skills/daily-retro/scripts/collect_logs.py 2026-09-02 # 日付指定(JST)
+    python3 .claude/skills/daily-retro/scripts/collect_logs.py 2026-09-02 --full  # 本文を長めに出す
+
+ログの前提（調べ直さないこと）:
+  - 置き場所は ~/.claude/projects/<cwd のスラッシュをハイフンにしたディレクトリ名>/<session-uuid>.jsonl
+  - ワークツリーごとに別ディレクトリになる（git worktree / orca workspaces も別扱い）
+  - timestamp は UTC。JST の「前日」は [D-1T15:00Z, DT15:00Z)
+  - サブエージェントのログは <session-uuid>/subagents/*.jsonl
+"""
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+JST = timezone(timedelta(hours=9))
+PROJECTS = os.path.expanduser("~/.claude/projects")
+# 対象プロジェクトの絞り込みキーワード（リポジトリ名）。必要なら書き換える。
+MATCH = os.environ.get("RETRO_MATCH", "siid-web")
+
+
+def jst_window(day: str):
+    d = datetime.strptime(day, "%Y-%m-%d").replace(tzinfo=JST)
+    start = d.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    end = (d + timedelta(days=1)).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    return start, end
+
+
+def iter_logs():
+    for root, _dirs, files in os.walk(PROJECTS):
+        if MATCH not in root:
+            continue
+        for name in files:
+            if name.endswith(".jsonl"):
+                yield os.path.join(root, name)
+
+
+def load(path):
+    rows = []
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows
+
+
+def blocks(entry):
+    content = (entry.get("message") or {}).get("content")
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return [b for b in (content or []) if isinstance(b, dict)]
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    full = "--full" in sys.argv
+    day = args[0] if args else (datetime.now(JST) - timedelta(days=1)).strftime("%Y-%m-%d")
+    start, end = jst_window(day)
+    limit = 4000 if full else 800
+
+    print(f"# 対象日(JST): {day}  / UTC window: {start} .. {end}  / match: {MATCH}\n")
+    found = 0
+    for path in sorted(iter_logs()):
+        rows = load(path)
+        stamps = [r["timestamp"] for r in rows if r.get("timestamp")]
+        if not stamps or max(stamps) < start or min(stamps) >= end:
+            continue
+        found += 1
+        rel = path.replace(PROJECTS + "/", "")
+        print("=" * 70)
+        print(f"## {rel}")
+        print(f"   全体: {min(stamps)[:19]}Z .. {max(stamps)[:19]}Z / entries={len(rows)}")
+        tools = {}
+        last_assistant = ""
+        interrupted = False
+        for r in rows:
+            ts = r.get("timestamp", "")
+            if not (start <= ts < end):
+                continue
+            kind = r.get("type")
+            for b in blocks(r):
+                if b.get("type") == "tool_use":
+                    tools[b.get("name")] = tools.get(b.get("name"), 0) + 1
+                    if kind == "assistant":
+                        inp = b.get("input") or {}
+                        hint = inp.get("command") or inp.get("file_path") or inp.get("prompt") or ""
+                        print(f"   [tool] {ts[11:19]} {b.get('name')}: {str(hint)[:140]}")
+                elif b.get("type") == "text":
+                    text = (b.get("text") or "").strip()
+                    if not text:
+                        continue
+                    if kind == "user":
+                        print(f"\n   [USER] {ts[11:19]}\n   " + text[:limit].replace("\n", "\n   ") + "\n")
+                    else:
+                        last_assistant = text
+                        if "API Error" in text or "went to sleep" in text:
+                            interrupted = True
+        print(f"\n   tool 内訳: {tools}")
+        if last_assistant:
+            print("   [最後の assistant 発話]\n   " + last_assistant[:limit].replace("\n", "\n   "))
+        if interrupted:
+            print("   !! このセッションは中断で終わっている（成果物が出ていない可能性が高い）")
+        print()
+    if not found:
+        print("対象日のセッションログなし。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #59

## 背景（前日 2026-09-02 の振り返り）

対象日の siid-web セッションは 1 本のみ（全ワークツリー横断で確認）。内容は同じ「日次振り返り」依頼で、結果は次のとおりだった。

- ツール呼び出し 7 回すべてが **「セッションログがどこにあるか」「前日ぶんをどう絞るか」の再発見** に費やされた
- しかも `grep '"timestamp":"2026-09-01'` で日付前方一致させており、ログが UTC・ローカルが JST のため 9 時間ぶんズレて絞り直しになった
- 成果物（スキル/ドキュメント/PR）を 1 つも出さないままセッションが中断し、作業が全部失われた（空のブランチ `docs/59-daily-retro-skill` だけが残っていた）

**より少ない手順で同じ質を出す方法**は、探索そのものを消すこと。よって手順とスクリプトを固定した。

## 変更内容

- `.claude/skills/daily-retro/SKILL.md` — 日次振り返りの手順書
  - ログの所在（ワークツリーごとに別ディレクトリ・orca workspaces 含む）、UTC/JST の前日レンジを「既知の前提」として明記し、再調査を禁止
  - 「何を反省点とみなすか」の着眼点と、**該当しなければ無理に変更を作らない**方針
  - **中断に強い順序**（Issue 起票 → `origin/develop` から分岐 → 書いたらすぐコミット）を明記
  - 依頼文のベースブランチ指定がプロジェクトルールと食い違う場合は CLAUDE.md 側に従う判断を明記
- `.claude/skills/daily-retro/scripts/collect_logs.py` — 前日(JST)のセッションを全ワークツリー分まとめて要約する収集スクリプト。ユーザー発話・ツール列・中断フラグを 1 コマンドで出す

これで次回以降、ログ収集は 1 コマンドで済む。

## 補足

CLAUDE.md のブランチ運用（本番ブランチへは develop からのリリース PR のみ）に従い、base は `develop` にしている。

## 確認

- `npm run lint` ✅ / `npm run typecheck` ✅
- `python3 .claude/skills/daily-retro/scripts/collect_logs.py` の動作確認済み（前日セッションを正しく抽出）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Re4qR2FqkgdoCt27p8XMit
